### PR TITLE
#148

### DIFF
--- a/gui/src/kg/api/queries/KgNodePageQuery.graphql
+++ b/gui/src/kg/api/queries/KgNodePageQuery.graphql
@@ -7,7 +7,7 @@ query KgNodePageQuery(
   kgById(id: $kgId) {
     nodeById(id: $nodeId) {
       ...KgNodeFieldsFragment
-      subjectOfEdges(limit: 100, offset: 0) {
+      topSubjectOfEdges(limit: 100) {
         object
         objectNode {
           id

--- a/gui/src/kg/api/queries/types/KgNodePageQuery.ts
+++ b/gui/src/kg/api/queries/types/KgNodePageQuery.ts
@@ -12,17 +12,17 @@ export interface KgNodePageQuery_kgById_nodeById_sources {
   label: string;
 }
 
-export interface KgNodePageQuery_kgById_nodeById_subjectOfEdges_objectNode {
+export interface KgNodePageQuery_kgById_nodeById_topSubjectOfEdges_objectNode {
   __typename: "KgNode";
   id: string;
   label: string | null;
   pos: string | null;
 }
 
-export interface KgNodePageQuery_kgById_nodeById_subjectOfEdges {
+export interface KgNodePageQuery_kgById_nodeById_topSubjectOfEdges {
   __typename: "KgEdge";
   object: string;
-  objectNode: KgNodePageQuery_kgById_nodeById_subjectOfEdges_objectNode | null;
+  objectNode: KgNodePageQuery_kgById_nodeById_topSubjectOfEdges_objectNode | null;
   predicate: string;
 }
 
@@ -33,7 +33,7 @@ export interface KgNodePageQuery_kgById_nodeById {
   id: string;
   label: string | null;
   pos: string | null;
-  subjectOfEdges: KgNodePageQuery_kgById_nodeById_subjectOfEdges[];
+  topSubjectOfEdges: KgNodePageQuery_kgById_nodeById_topSubjectOfEdges[];
 }
 
 export interface KgNodePageQuery_kgById {

--- a/gui/src/shared/components/kg/node/KgNodeViews.tsx
+++ b/gui/src/shared/components/kg/node/KgNodeViews.tsx
@@ -29,7 +29,7 @@ export const KgNodeViews: React.FunctionComponent<{
     label: string | null;
     pos: string | null;
     sources: KgSource[];
-    subjectOfEdges: KgNodeSubjectOfEdge[];
+    topSubjectOfEdges: KgNodeSubjectOfEdge[];
   };
 }> = ({node}) => {
   const location = useLocation();
@@ -45,7 +45,7 @@ export const KgNodeViews: React.FunctionComponent<{
   const predicateSubjects: {
     [index: string]: KgNodeSubjectOfEdge[];
   } = {};
-  for (const edge of node.subjectOfEdges) {
+  for (const edge of node.topSubjectOfEdges) {
     if (!edge.objectNode) {
       continue;
     } else if (!edge.predicate) {

--- a/lib/scala/kg/src/main/scala/models/graphql/AbstractKgGraphQlSchemaDefinition.scala
+++ b/lib/scala/kg/src/main/scala/models/graphql/AbstractKgGraphQlSchemaDefinition.scala
@@ -45,7 +45,9 @@ abstract class AbstractKgGraphQlSchemaDefinition extends BaseGraphQlSchemaDefini
     Field("other", OptionType(StringType), resolve = _ => None),
     Field("pageRank", FloatType, resolve = _.value.pageRank.get),
     Field("pos", OptionType(StringType), resolve = _.value.pos),
-    Field("subjectOfEdges", ListType(KgEdgeType), arguments = LimitArgument :: OffsetArgument :: Nil, resolve = ctx => ctx.ctx.kgStore.getEdgesBySubject(limit = ctx.args.arg(LimitArgument), offset = ctx.args.arg(OffsetArgument), subjectNodeId = ctx.value.id))
+    Field("subjectOfEdges", ListType(KgEdgeType), arguments = LimitArgument :: OffsetArgument :: Nil, resolve = ctx => ctx.ctx.kgStore.getEdgesBySubject(limit = ctx.args.arg(LimitArgument), offset = ctx.args.arg(OffsetArgument), subjectNodeId = ctx.value.id)),
+    Field("topObjectOfEdges", ListType(KgEdgeType), arguments = LimitArgument :: Nil, resolve = ctx => ctx.ctx.kgStore.getTopEdgesByObject(limit = ctx.args.arg(LimitArgument), objectNodeId = ctx.value.id)),
+    Field("topSubjectOfEdges", ListType(KgEdgeType), arguments = LimitArgument :: Nil, resolve = ctx => ctx.ctx.kgStore.getTopEdgesBySubject(limit = ctx.args.arg(LimitArgument), subjectNodeId = ctx.value.id))
   ))
   val KgPathType = deriveObjectType[KgGraphQlSchemaContext, KgPath](
     AddFields(

--- a/lib/scala/kg/src/main/scala/stores/kg/KgStore.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/KgStore.scala
@@ -59,7 +59,17 @@ trait KgStore {
   def getRandomNode: KgNode
 
   /**
-   * Get toal number of edges.
+   * Get top edges using pageRank grouped by relation that have the given node ID as an object
+   */
+  def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge]
+
+  /**
+   * Get top edges using pageRank grouped by relation that have the given node ID as a subject
+   */
+  def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge]
+
+  /**
+   * Get total number of edges.
    */
   def getTotalEdgesCount: Int;
 

--- a/lib/scala/kg/src/main/scala/stores/kg/mem/MemKgStore.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/mem/MemKgStore.scala
@@ -86,11 +86,11 @@ class MemKgStore extends KgStore {
   override def getRandomNode: KgNode =
     nodes(random.nextInt(nodes.size))
 
-  override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
-    edges.filter(_.`object` == objectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.subject).pageRank).take(limit)).values.flatten.toList
+  final override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
+    edges.filter(_.`object` == objectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.subject).pageRank.get).take(limit)).values.flatten.toList
 
-  override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
-    edges.filter(_.subject == subjectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.`object`).pageRank).take(limit)).values.flatten.toList
+  final override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
+    edges.filter(_.subject == subjectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.`object`).pageRank.get).take(limit)).values.flatten.toList
 
   final override def getTotalEdgesCount: Int =
     edges.size

--- a/lib/scala/kg/src/main/scala/stores/kg/mem/MemKgStore.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/mem/MemKgStore.scala
@@ -87,10 +87,10 @@ class MemKgStore extends KgStore {
     nodes(random.nextInt(nodes.size))
 
   final override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
-    edges.filter(_.`object` == objectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.subject).pageRank.get).take(limit)).values.flatten.toList
+    edges.filter(_.`object` == objectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.subject).pageRank.get)(Ordering[Double].reverse).take(limit)).values.flatten.toList
 
   final override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
-    edges.filter(_.subject == subjectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.`object`).pageRank.get).take(limit)).values.flatten.toList
+    edges.filter(_.subject == subjectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.`object`).pageRank.get)(Ordering[Double].reverse).take(limit)).values.flatten.toList
 
   final override def getTotalEdgesCount: Int =
     edges.size

--- a/lib/scala/kg/src/main/scala/stores/kg/mem/MemKgStore.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/mem/MemKgStore.scala
@@ -86,6 +86,12 @@ class MemKgStore extends KgStore {
   override def getRandomNode: KgNode =
     nodes(random.nextInt(nodes.size))
 
+  override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
+    edges.filter(_.`object` == objectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.subject).pageRank).take(limit)).values.flatten.toList
+
+  override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
+    edges.filter(_.subject == subjectNodeId).groupBy(_.predicate).mapValues(_.sortBy(edge => nodesById(edge.`object`).pageRank).take(limit)).values.flatten.toList
+
   final override def getTotalEdgesCount: Int =
     edges.size
 

--- a/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStore.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStore.scala
@@ -128,12 +128,12 @@ final class Neo4jKgStore @Inject()(configuration: Neo4jStoreConfiguration) exten
       transaction.getRandomNode
     }
 
-  override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
+  final override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
     withReadTransaction { transaction =>
       transaction.getTopEdgesByObject(limit, objectNodeId)
     }
 
-  override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
+  final override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
     withReadTransaction { transaction =>
       transaction.getTopEdgesBySubject(limit, subjectNodeId)
     }

--- a/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStore.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStore.scala
@@ -128,6 +128,16 @@ final class Neo4jKgStore @Inject()(configuration: Neo4jStoreConfiguration) exten
       transaction.getRandomNode
     }
 
+  override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] =
+    withReadTransaction { transaction =>
+      transaction.getTopEdgesByObject(limit, objectNodeId)
+    }
+
+  override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] =
+    withReadTransaction { transaction =>
+      transaction.getTopEdgesBySubject(limit, subjectNodeId)
+    }
+
   final override def getTotalEdgesCount: Int =
     withReadTransaction { transaction =>
       transaction.getTotalEdgesCount

--- a/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreRecordWrapper.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreRecordWrapper.scala
@@ -19,25 +19,18 @@ class Neo4jKgStoreRecordWrapper(record: Record) {
 
   def toEdge: KgEdge = {
     val recordMap = record.asMap().asScala.toMap
-    try {
-      KgEdge(
-        id = recordMap("edge.id").asInstanceOf[String],
-        labels = toList(recordMap("edge.labels").asInstanceOf[String]),
-        `object` = recordMap("object.id").asInstanceOf[String],
-        origins = toList(recordMap("edge.origins").asInstanceOf[String]),
-        questions = toList(recordMap("edge.questions").asInstanceOf[String]),
-        sentences = toList(recordMap("edge.sentences").asInstanceOf[String]),
-        predicate = recordMap("type(edge)").asInstanceOf[String],
-        sources = toList(recordMap("edge.sources").asInstanceOf[String]),
-        subject = recordMap("subject.id").asInstanceOf[String],
-        weight = Option(recordMap("edge.weight")).map(weight => weight.asInstanceOf[Double].doubleValue())
-      )
-    } catch {
-      case e: NullPointerException => {
-        println(recordMap)
-        throw e
-      }
-    }
+    KgEdge(
+      id = recordMap("edge.id").asInstanceOf[String],
+      labels = toList(recordMap("edge.labels").asInstanceOf[String]),
+      `object` = recordMap("object.id").asInstanceOf[String],
+      origins = toList(recordMap("edge.origins").asInstanceOf[String]),
+      questions = toList(recordMap("edge.questions").asInstanceOf[String]),
+      sentences = toList(recordMap("edge.sentences").asInstanceOf[String]),
+      predicate = recordMap("type(edge)").asInstanceOf[String],
+      sources = toList(recordMap("edge.sources").asInstanceOf[String]),
+      subject = recordMap("subject.id").asInstanceOf[String],
+      weight = Option(recordMap("edge.weight")).map(weight => weight.asInstanceOf[Double].doubleValue())
+    )
   }
 
   def toNode: KgNode = {

--- a/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreRecordWrapper.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreRecordWrapper.scala
@@ -19,18 +19,25 @@ class Neo4jKgStoreRecordWrapper(record: Record) {
 
   def toEdge: KgEdge = {
     val recordMap = record.asMap().asScala.toMap
-    KgEdge(
-      id = recordMap("edge.id").asInstanceOf[String],
-      labels = toList(recordMap("edge.labels").asInstanceOf[String]),
-      `object` = recordMap("object.id").asInstanceOf[String],
-      origins = toList(recordMap("edge.origins").asInstanceOf[String]),
-      questions = toList(recordMap("edge.questions").asInstanceOf[String]),
-      sentences = toList(recordMap("edge.sentences").asInstanceOf[String]),
-      predicate = recordMap("type(edge)").asInstanceOf[String],
-      sources = toList(recordMap("edge.sources").asInstanceOf[String]),
-      subject = recordMap("subject.id").asInstanceOf[String],
-      weight = Option(recordMap("edge.weight")).map(weight => weight.asInstanceOf[Double].doubleValue())
-    )
+    try {
+      KgEdge(
+        id = recordMap("edge.id").asInstanceOf[String],
+        labels = toList(recordMap("edge.labels").asInstanceOf[String]),
+        `object` = recordMap("object.id").asInstanceOf[String],
+        origins = toList(recordMap("edge.origins").asInstanceOf[String]),
+        questions = toList(recordMap("edge.questions").asInstanceOf[String]),
+        sentences = toList(recordMap("edge.sentences").asInstanceOf[String]),
+        predicate = recordMap("type(edge)").asInstanceOf[String],
+        sources = toList(recordMap("edge.sources").asInstanceOf[String]),
+        subject = recordMap("subject.id").asInstanceOf[String],
+        weight = Option(recordMap("edge.weight")).map(weight => weight.asInstanceOf[Double].doubleValue())
+      )
+    } catch {
+      case e: NullPointerException => {
+        println(recordMap)
+        throw e
+      }
+    }
   }
 
   def toNode: KgNode = {

--- a/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreTransactionWrapper.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreTransactionWrapper.scala
@@ -119,6 +119,7 @@ class Neo4jKgStoreTransactionWrapper(configuration: Neo4jStoreConfiguration, tra
     transaction.run(
       s"""
          |MATCH (subject:Node)-[edge]->(object:Node {id: $$objectNodeId})
+         |WHERE type(edge)<>"PATH"
          |WITH edge, subject, object
          |ORDER BY subject.pageRank DESC
          |WITH type(edge) as relation, collect([edge, subject, object])[0 .. ${limit}] as groupByRelation
@@ -139,6 +140,7 @@ class Neo4jKgStoreTransactionWrapper(configuration: Neo4jStoreConfiguration, tra
     transaction.run(
       s"""
          |MATCH (subject:Node {id: $$subjectNodeId})-[edge]->(object:Node)
+         |WHERE type(edge)<>"PATH"
          |WITH edge, subject, object
          |ORDER BY object.pageRank DESC
          |WITH type(edge) as relation, collect([edge, subject, object])[0 .. ${limit}] as groupByRelation

--- a/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreTransactionWrapper.scala
+++ b/lib/scala/kg/src/main/scala/stores/kg/neo4j/Neo4jKgStoreTransactionWrapper.scala
@@ -115,7 +115,7 @@ class Neo4jKgStoreTransactionWrapper(configuration: Neo4jStoreConfiguration, tra
   /**
    * Get top edges using pageRank grouped by relation that have the given node ID as an object
    */
-  override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] = {
+  final override def getTopEdgesByObject(limit: Int, objectNodeId: String): List[KgEdge] = {
     transaction.run(
       s"""
          |MATCH (subject:Node)-[edge]->(object:Node {id: $$objectNodeId})
@@ -136,7 +136,7 @@ class Neo4jKgStoreTransactionWrapper(configuration: Neo4jStoreConfiguration, tra
   /**
    * Get top edges using pageRank grouped by relation that have the given node ID as a subject
    */
-  override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] = {
+  final override def getTopEdgesBySubject(limit: Int, subjectNodeId: String): List[KgEdge] = {
     transaction.run(
       s"""
          |MATCH (subject:Node {id: $$subjectNodeId})-[edge]->(object:Node)

--- a/lib/scala/kg/src/test/scala/stores/kg/KgStoreBehaviors.scala
+++ b/lib/scala/kg/src/test/scala/stores/kg/KgStoreBehaviors.scala
@@ -76,7 +76,7 @@ trait KgStoreBehaviors extends Matchers { this: WordSpec =>
 
     "get top edges by object" in {
       storeFactory(TestMode.ReadOnly) { sut =>
-        val limit = 2
+        val limit = 3
         val objectNodeId = TestKgData.nodes(0).id
         val actual = sut.getTopEdgesByObject(limit, objectNodeId)
 
@@ -85,7 +85,7 @@ trait KgStoreBehaviors extends Matchers { this: WordSpec =>
         for (partitionEnd <- 1 until actual.size + 1) {
           if (partitionEnd == actual.size || actual(partitionEnd).predicate != actual(partitionStart).predicate) {
             partitionEnd - partitionStart should be <= limit
-            actual.slice(partitionStart, partitionEnd) should equal(objectEdges.filter(_.predicate == actual(partitionStart).predicate).sortBy(edge => TestKgData.nodesById(edge.subject).pageRank.get).take(limit))
+            actual.slice(partitionStart, partitionEnd) should equal(objectEdges.filter(_.predicate == actual(partitionStart).predicate).sortBy(edge => TestKgData.nodesById(edge.subject).pageRank.get)(Ordering[Double].reverse).take(limit))
 
             partitionStart = partitionEnd
           }
@@ -95,7 +95,7 @@ trait KgStoreBehaviors extends Matchers { this: WordSpec =>
 
     "get top edges by subject" in {
       storeFactory(TestMode.ReadOnly) { sut =>
-        val limit = 2
+        val limit = 3
         val subjectNodeId = TestKgData.nodes(0).id
         val actual = sut.getTopEdgesBySubject(limit, subjectNodeId)
 
@@ -104,7 +104,7 @@ trait KgStoreBehaviors extends Matchers { this: WordSpec =>
         for (partitionEnd <- 1 until actual.size + 1) {
           if (partitionEnd == actual.size || actual(partitionEnd).predicate != actual(partitionStart).predicate) {
             partitionEnd - partitionStart should be <= limit
-            actual.slice(partitionStart, partitionEnd) should equal(subjectEdges.filter(_.predicate == actual(partitionStart).predicate).sortBy(edge => TestKgData.nodesById(edge.`object`).pageRank.get).take(limit))
+            actual.slice(partitionStart, partitionEnd) should equal(subjectEdges.filter(_.predicate == actual(partitionStart).predicate).sortBy(edge => TestKgData.nodesById(edge.`object`).pageRank.get)(Ordering[Double].reverse).take(limit))
 
             partitionStart = partitionEnd
           }

--- a/lib/scala/kg/src/test/scala/stores/kg/KgStoreBehaviors.scala
+++ b/lib/scala/kg/src/test/scala/stores/kg/KgStoreBehaviors.scala
@@ -74,6 +74,44 @@ trait KgStoreBehaviors extends Matchers { this: WordSpec =>
       }
     }
 
+    "get top edges by object" in {
+      storeFactory(TestMode.ReadOnly) { sut =>
+        val limit = 2
+        val objectNodeId = TestKgData.nodes(0).id
+        val actual = sut.getTopEdgesByObject(limit, objectNodeId)
+
+        val objectEdges = TestKgData.edges.filter(_.`object` == objectNodeId)
+        var partitionStart = 0
+        for (partitionEnd <- 1 until actual.size + 1) {
+          if (partitionEnd == actual.size || actual(partitionEnd).predicate != actual(partitionStart).predicate) {
+            partitionEnd - partitionStart should be <= limit
+            actual.slice(partitionStart, partitionEnd) should equal(objectEdges.filter(_.predicate == actual(partitionStart).predicate).sortBy(edge => TestKgData.nodesById(edge.subject).pageRank.get).take(limit))
+
+            partitionStart = partitionEnd
+          }
+        }
+      }
+    }
+
+    "get top edges by subject" in {
+      storeFactory(TestMode.ReadOnly) { sut =>
+        val limit = 2
+        val subjectNodeId = TestKgData.nodes(0).id
+        val actual = sut.getTopEdgesBySubject(limit, subjectNodeId)
+
+        val subjectEdges = TestKgData.edges.filter(_.subject == subjectNodeId)
+        var partitionStart = 0
+        for (partitionEnd <- 1 until actual.size + 1) {
+          if (partitionEnd == actual.size || actual(partitionEnd).predicate != actual(partitionStart).predicate) {
+            partitionEnd - partitionStart should be <= limit
+            actual.slice(partitionStart, partitionEnd) should equal(subjectEdges.filter(_.predicate == actual(partitionStart).predicate).sortBy(edge => TestKgData.nodesById(edge.`object`).pageRank.get).take(limit))
+
+            partitionStart = partitionEnd
+          }
+        }
+      }
+    }
+
     "get count of matching nodes by label" in {
       storeFactory(TestMode.ReadOnly) { sut =>
         val expected = TestKgData.nodes(0)


### PR DESCRIPTION
Change node page to show top edges by relation

Added `getTopEdgesByObject` and `getTopEdgesBySubject` to `KgStore`
Added `topObjectofEdges` and `topSubjectOfEdges` to `KgNode` graphql
Changed `KgNodePage` to use `topSubjectOfEdges` instead of `subjectOfEdges`

Closes #148