### PR TITLE
#207

### DIFF
--- a/gui/src/shared/components/kg/node/KgNodeLink.tsx
+++ b/gui/src/shared/components/kg/node/KgNodeLink.tsx
@@ -3,22 +3,31 @@ import {Hrefs} from "shared/Hrefs";
 import {Link} from "react-router-dom";
 import {kgId} from "shared/api/kgId";
 import {KgSource} from "shared/models/kg/source/KgSource";
+import {KgSourcePill} from "../source/KgSourcePill";
+import {KgNodePosBadge} from "./KgNodePosBadge";
 
 export const KgNodeLink: React.FunctionComponent<{
   node: {id: string; label: string | null; pos: string | null};
   sources?: KgSource[];
 }> = ({node, sources}) => {
+  const label = node.label ?? node.id;
   return (
     <Link
       data-cy="node-link"
       title={node.id}
       to={Hrefs.kg({id: kgId}).node({id: node.id})}
     >
-      {(node.label ? node.label : node.id) +
-        (node.pos ? " (" + node.pos + ")" : "") +
-        (sources && sources.length > 0
-          ? " - " + sources.map((source) => source.label).join(" | ")
-          : "")}
+      <span style={{marginRight: "5px"}}>
+        {node.pos ? (
+          <KgNodePosBadge badgeContent={node.pos} color="primary">
+            {label}
+          </KgNodePosBadge>
+        ) : (
+          label
+        )}
+      </span>
+      {sources &&
+        sources.map((source) => <KgSourcePill source={source} size="small" />)}
     </Link>
   );
 };

--- a/gui/src/shared/components/kg/node/KgNodePosBadge.tsx
+++ b/gui/src/shared/components/kg/node/KgNodePosBadge.tsx
@@ -1,0 +1,13 @@
+import {withStyles, createStyles, Theme, Badge} from "@material-ui/core";
+
+export const KgNodePosBadge = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      paddingRight: "15px",
+    },
+    badge: {
+      right: 5,
+      top: 0,
+    },
+  })
+)(Badge);

--- a/gui/src/shared/components/kg/source/KgSourcePill.tsx
+++ b/gui/src/shared/components/kg/source/KgSourcePill.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {KgSource} from "shared/models/kg/source/KgSource";
-import {Chip} from "@material-ui/core";
+import {Chip, ChipProps} from "@material-ui/core";
 import {useHistory} from "react-router-dom";
 import {Hrefs} from "shared/Hrefs";
 import {kgId} from "shared/api/kgId";
@@ -8,9 +8,9 @@ import * as d3 from "d3";
 
 const colors = d3.scaleOrdinal(d3.schemeTableau10);
 
-export const KgSourcePill: React.FunctionComponent<{source: KgSource}> = ({
-  source,
-}) => {
+export const KgSourcePill: React.FunctionComponent<
+  {source: KgSource} & ChipProps
+> = ({source, ...chipProps}) => {
   const history = useHistory();
 
   const color = colors(source.id);
@@ -33,6 +33,7 @@ export const KgSourcePill: React.FunctionComponent<{source: KgSource}> = ({
         );
       }}
       style={{color, borderColor: color, margin: "2px"}}
+      {...chipProps}
     />
   );
 };


### PR DESCRIPTION
Closes #207 

Add a `KgNodePosBadge` for showing part of speech of a node using material-ui `Badge` component
Use `KgNodePosBadge` and `KgSourcePill` in `KgNodeLink`

With hardcoded part of speech
![Screen Shot 2020-08-24 at 1 59 54 PM](https://user-images.githubusercontent.com/9285017/91096877-99f5a080-e613-11ea-8d3a-7a14a80b215d.png)

Without part of speech
![Screen Shot 2020-08-24 at 2 11 03 PM](https://user-images.githubusercontent.com/9285017/91096945-b42f7e80-e613-11ea-86ed-51073b1f5356.png)
